### PR TITLE
Creating method for saving as authenticated, when tokens are provided

### DIFF
--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1419,12 +1419,13 @@ function openidc.authenticate(opts, target_url, unauth_action, session_opts)
   local path = openidc_get_path(target_url)
   local redirect_uri = openidc_get_redirect_uri_path(opts)
   log(DEBUG, "Target URL: " .. target_url)
+  log(DEBUG, "Path: " .. path)
   if(redirect_uri) then
     log(DEBUG, "openidc_get_redirect_uri_path: " .. target_url)
   else
     log(DEBUG, "redirect uri is null")
   end
-  if path == openidc_get_redirect_uri_path(opts) and string.find(target_url,"state=") then
+  if path == redirect_uri and string.find(target_url,"state=") then
     log(DEBUG, "Redirect URI path (" .. path .. ") is currently navigated -> Processing authorization response coming from OP")
 
     if not session.present then

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1417,7 +1417,13 @@ function openidc.authenticate(opts, target_url, unauth_action, session_opts)
 
   -- see if this is a request to the redirect_uri i.e. an authorization response
   local path = openidc_get_path(target_url)
+  local redirect_uri = openidc_get_redirect_uri_path(opts)
   log(DEBUG, "Target URL: " .. target_url)
+  if(redirect_uri) then
+    log(DEBUG, "openidc_get_redirect_uri_path: " .. target_url)
+  else
+    log(DEBUG, "redirect uri is null")
+  end
   if path == openidc_get_redirect_uri_path(opts) and string.find(target_url,"state=") then
     log(DEBUG, "Redirect URI path (" .. path .. ") is currently navigated -> Processing authorization response coming from OP")
 

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1138,7 +1138,7 @@ local function openidc_authorization_response(opts, session)
   return save_as_authenticated(opts,session,json,id_token)
 end
 
-local function save_as_authenticated(opts,session,json,id_token)
+function save_as_authenticated(opts,session,json,id_token)
   -- mark this sessions as authenticated
   session.data.authenticated = true
   -- clear state, nonce and code_verifier to protect against potential misuse

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1421,7 +1421,7 @@ function openidc.authenticate(opts, target_url, unauth_action, session_opts)
   log(DEBUG, "Target URL: " .. target_url)
   log(DEBUG, "Path: " .. path)
   if(redirect_uri) then
-    log(DEBUG, "openidc_get_redirect_uri_path: " .. target_url)
+    log(DEBUG, "openidc_get_redirect_uri_path: " .. redirect_uri)
   else
     log(DEBUG, "redirect uri is null")
   end

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1135,6 +1135,10 @@ local function openidc_authorization_response(opts, session)
     return nil, err, session.data.original_url, session
   end
 
+  return save_as_authenticated(opts,session,json,id_token)
+end
+
+local function save_as_authenticated(opts,session,json,id_token)
   -- mark this sessions as authenticated
   session.data.authenticated = true
   -- clear state, nonce and code_verifier to protect against potential misuse

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -149,11 +149,10 @@ local function openidc_validate_id_token(opts, id_token, nonce)
     return false
   end
 
-  -- TODO put this back!!! check nonce
-  --if nonce and nonce ~= id_token.nonce then
-  --  log(ERROR, "nonce \"", id_token.nonce, "\" in id_token is not equal to the nonce that was sent in the request \"", nonce, "\"")
-  --  return false
- -- end
+  if opts.ignore_nonce_validation and opts.ignore_nonce_validation == 'yes' and nonce and nonce ~= id_token.nonce then
+    log(ERROR, "nonce \"", id_token.nonce, "\" in id_token is not equal to the nonce that was sent in the request \"", nonce, "\"")
+    return false
+  end
 
   -- check issued-at timestamp
   if not id_token.iat then

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1139,6 +1139,7 @@ local function openidc_authorization_response(opts, session)
 end
 
 function save_as_authenticated(opts,session,json,id_token)
+  log(DEBUG, "Saving as authenticated")
   -- mark this sessions as authenticated
   session.data.authenticated = true
   -- clear state, nonce and code_verifier to protect against potential misuse


### PR DESCRIPTION
## PQ
Atender necessidade de salvar sessao autenticada via metodo
Isso foi implementado pois o Amplify nao suporta autenticacao oauth (authorizartion code flow). Já registrado chamado na AWS conforme: https://contaazul.atlassian.net/wiki/spaces/ARCH/pages/889094397/Processo+de+SIGN+IN

## OQ
Adicionado metodo para iniciar sessao com token informado. Isso será usado por rota espeicifca no kong para inicializar a sessão

Verificação do nonce pode falhar em casos de depuração (token manual). Nesse caso temos a conf pra desabilitar,

Mas o fluxo do authentication-front funciona corretamente pois o ignore_nonce_validation eh false
![image](https://user-images.githubusercontent.com/916289/102929019-8c90db80-4478-11eb-8caa-df214f7adacb.png)
