### PR TITLE
Bypass do fluxo de user info e redirect opcional

### DIFF
--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1202,8 +1202,8 @@ function openidc.save_as_authenticated(opts,session,json)
     session.data.original_url = openidc_get_redirect_uri(opts)
   end
   -- redirect to the URL that was accessed originally
-  log(DEBUG, "OIDC Authorization Code Flow completed -> Redirecting to original URL (" .. session.data.original_url .. ")")
-  ngx.redirect(session.data.original_url)
+  --log(DEBUG, "OIDC Authorization Code Flow completed -> Redirecting to original URL (" .. session.data.original_url .. ")")
+  --ngx.redirect(session.data.original_url)
   return nil, nil, session.data.original_url, session
 end
 

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1160,7 +1160,7 @@ function openidc.save_as_authenticated(opts,session,json)
   end
 
   
-  if oidcConfig.inject_user and oidcConfig.inject_user == "yes" and store_in_session(opts, 'user') then
+  if opts.inject_user and opts.inject_user == "yes" and store_in_session(opts, 'user') then
     -- call the user info endpoint
     -- TODO: should this error be checked?
     local user

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1127,10 +1127,10 @@ local function openidc_authorization_response(opts, session)
   if err then
     return nil, err, session.data.original_url, session
   end
-  return openidc.save_as_authenticated(opts,session,json)
+  return openidc.save_as_authenticated(opts,session,json,true)
 end
 
-function openidc.save_as_authenticated(opts,session,json)
+function openidc.save_as_authenticated(opts,session,json,do_redirect)
   if opts.scope then
     log(DEBUG, "Scope: " .. opts.scope)
   end
@@ -1201,9 +1201,11 @@ function openidc.save_as_authenticated(opts,session,json)
   if not session.data.original_url then
     session.data.original_url = openidc_get_redirect_uri(opts)
   end
-  -- redirect to the URL that was accessed originally
-  --log(DEBUG, "OIDC Authorization Code Flow completed -> Redirecting to original URL (" .. session.data.original_url .. ")")
-  --ngx.redirect(session.data.original_url)
+  if do_redirect then  
+    -- redirect to the URL that was accessed originally
+    log(DEBUG, "OIDC Authorization Code Flow completed -> Redirecting to original URL (" .. session.data.original_url .. ")")
+    ngx.redirect(session.data.original_url)
+  end
   return nil, nil, session.data.original_url, session
 end
 

--- a/lib/resty/openidc.lua
+++ b/lib/resty/openidc.lua
@@ -1131,6 +1131,10 @@ local function openidc_authorization_response(opts, session)
 end
 
 function openidc.save_as_authenticated(opts,session,json)
+  if opts.scope then
+    log(DEBUG, "Scope: " .. opts.scope)
+  end
+
   local current_time = ngx.time()
   if session == nil then
     session, session_error = r_session.start(session_opts)
@@ -1155,7 +1159,8 @@ function openidc.save_as_authenticated(opts,session,json)
     session.data.id_token = id_token
   end
 
-  if store_in_session(opts, 'user') then
+  
+  if oidcConfig.inject_user and oidcConfig.inject_user == "yes" and store_in_session(opts, 'user') then
     -- call the user info endpoint
     -- TODO: should this error be checked?
     local user


### PR DESCRIPTION
## PQ
- como usamos o token gerado pelo amplify (que nao possui open id scope), não é possivel chamar o endpoint de userinfo. Por isso, vamos parametrizar a chamada do userinfo usando a config inject_user
- Boostrap nao pode fazer redirect, portanto save as authenticated deve ser parametrizavel, conforme: https://github.com/ContaAzul/kong-oidc/pull/4

## OQ
- Verificando reditect_to para fazer redirect no bootrap
- Verificando inject_user para chamar userinfo